### PR TITLE
[IMP] Add context if possible when translation .po

### DIFF
--- a/commands/translate.py
+++ b/commands/translate.py
@@ -123,7 +123,6 @@ class TranslateCommand(DatabaseCommand):
                 process.additional_addons_paths.append(self.args.path.parent)
 
         elif isinstance(self._database, LocalDatabase):
-            odoo_context = OdooContext(self._database._get_process_instance())
             process = self._database._get_process_instance()
         else:
             raise ValueError("Unsupported database type for fetching context.")


### PR DESCRIPTION
The idea is to use the string in the Po 

`#: code:addons/project/static/src/components/notebook_task_one2many_field/notebook_task_list_renderer.js:0` 

To pass in the prompt the context with the file content when possible.