### PR TITLE
[REF] Refactor using a Prompt class

### DIFF
--- a/commands/translate.py
+++ b/commands/translate.py
@@ -15,7 +15,8 @@ from odev.common.logging import logging
 from odev.common.odoobin import OdoobinProcess
 
 from odev.plugins.odev_plugin_ai.common.llm import LLM
-from odev.plugins.odev_plugin_ai.common.odoo_context import Context, OdooContext
+from odev.plugins.odev_plugin_ai.common.llm_prompt import LLMPrompt
+from odev.plugins.odev_plugin_ai.common.odoo_context import OdooContext
 
 
 logger = logging.getLogger(__name__)
@@ -115,8 +116,6 @@ class TranslateCommand(DatabaseCommand):
 
         self.llm = LLM(llm_order=self.config.ai.llm_order)
 
-        context = ""
-
         if isinstance(self._database, RemoteDatabase):
             database = LocalDatabase(self._database.name)
             process = OdoobinProcess(database, version=self._database.version)
@@ -134,35 +133,23 @@ class TranslateCommand(DatabaseCommand):
 
         process.update_worktrees()
         odoo_context = OdooContext(process)
-        context = odoo_context.gather_po_context(po_content)
+        context_prompt = odoo_context.gather_po_context(po_content)
 
-        po_context = Context()
-        po_context.add_file(self.args.module_name, "translation.po", po_content)
-
-        messages = [
-            {
-                "role": "system",
-                "content": (
-                    f"Translate the provided PO file into {self.args.lang} (ISO code)."
-                    "Just answer the result merged into the original file without the code block string."
-                    "If a context is provided, use it to improve the translation of specific terms."
-                ),
-            },
-            {
-                "role": "user",
-                "content": [
-                    {"type": "text", "text": "Here's the PO source file"},
-                    po_context,
-                    {"type": "text", "text": "And the related context files"},
-                    context,
-                ],
-            },
-        ]
+        prompt = LLMPrompt()
+        prompt.set_system(
+            f"Translate the provided PO file into {self.args.lang} (ISO code)."
+            "Just answer the result merged into the original file without the code block string."
+            "If a context is provided, use it to improve the translation of specific terms."
+        )
+        prompt.add_user("Here's the PO source file")
+        prompt.add_file(f"{self.args.module_name}/translation.po", po_content)
+        prompt.add_user("And the related context files")
+        prompt.add_user(context_prompt._user_parts)
 
         logger.debug(f"Calling LLM '{self.llm.model}' for translation of PO content (length: {len(po_content)})")
 
         with progress.spinner(f"Waiting for '{self.llm.model}' to complete the translation"):
-            ai_translation = self.llm.completion(messages)
+            ai_translation = self.llm.completion(prompt)
 
         if not ai_translation:
             raise ValueError("AI translation failed or returned no content.")


### PR DESCRIPTION
## Description

This PR refactors the AI translation command to improve consistency with the core AI module's architecture:

*   **Prompt Class Integration**: Transitioned the `TranslateCommand` from manual dictionary-based message construction to the standard `LLMPrompt` class. 
*   **Improved Content Handling**: Simplified how the PO source file and its related context files are added to the LLM request. The code is now cleaner, more readable, and leverages the robust `add_file` and `add_user` methods of the `LLMPrompt` structure.
*   **Future-Proofing**: This refactoring ensures that the translation module benefits from any future improvements made to the shared prompt and LLM handling infrastructure.

## Compliance

- [x] I have read the [contribution guide](../docs/CONTRIBUTING.md)
- [x] I made sure the documentation is up-to-date both in doctrings and the `docs` directory
- [ ] I have added or modified unit tests where necessary
- [ ] I have added new libraries to the [requirements.txt](cci:7://file:///home/crupuk/odoo/repositories/odoo-odev/odev-plugin-ai/requirements.txt:0:0-0:0) file, if any
- [ ] I have incremented the version number according the [versioning guide](../../docs/contributing/versioning.md)
- [x] The PR contains **my changes only** and **no other external commit**